### PR TITLE
Don't use set_rcvar as it has been removed from rc.subr

### DIFF
--- a/rmilter.sh
+++ b/rmilter.sh
@@ -15,7 +15,7 @@
 . /etc/rc.subr
 
 name="rmilter"
-rcvar=`set_rcvar`
+rcvar=rmilter_enable
 procname="/usr/local/sbin/rmilter"
 
 load_rc_config $name


### PR DESCRIPTION
This patch fix a (minor) bug in the FreeBSD rc.d rmilter script. Before the patch:

```
# service rmilter.sh restart
/usr/local/etc/rc.d/rmilter.sh: set_rcvar: not found
# pkg info | grep rmilter
rmilter-1.6.1_1                Milter that performs spamd, clamav, and spf checks
# freebsd-version 
10.0-RELEASE-p9
```
