### PR TITLE
Fix doc: add reference to strict_auth directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Directives that can be defined in config file:
 
         > *Default:* **0 (no limit)**
 
+    - **strict\_auth**: strict checks for mails from authenticated senders
+
+        > *Default:* **no**
+
     - **spf\_domains**: list of domains that would be checked with spf
 
         > *Default:* **empty (spf disabled)**
@@ -542,7 +546,13 @@ Example configuration
 
     # max_size - maximum size of scanned mail with clamav and dcc
     # Default: 0 (no limit)
+
     max_size = 10M;
+
+    # strict_auth - strict checks for mails from authenticated senders
+    # Default: no
+
+    strict_auth = no;
 
     # spf_domains - path to file that contains hash of spf domains
     # Default: empty

--- a/centos/rmilter.conf.common
+++ b/centos/rmilter.conf.common
@@ -157,7 +157,13 @@ tempdir = /tmp;
 
 # max_size - maximum size of scanned mail with clamav and dcc
 # Default: 0 (no limit)
+
 max_size = 10M;
+
+# strict_auth - strict checks for mails from authenticated senders
+# Default: no
+
+strict_auth = no;
 
 # spf_domains - path to file that contains hash of spf domains
 # Default: empty

--- a/debian/rmilter.conf.common
+++ b/debian/rmilter.conf.common
@@ -157,7 +157,13 @@ tempdir = /tmp;
 
 # max_size - maximum size of scanned mail with clamav and dcc
 # Default: 0 (no limit)
+
 max_size = 10M;
+
+# strict_auth - strict checks for mails from authenticated senders
+# Default: no
+
+strict_auth = no;
 
 # spf_domains - path to file that contains hash of spf domains
 # Default: empty

--- a/doc/rmilter.8
+++ b/doc/rmilter.8
@@ -157,6 +157,10 @@ inet:port@host - bind to inet socket
 - maximum size of scanned message for clamav, spamd and dcc.
 .Dl Em Default: Li 0 Pq no limit
 .It 
+.Sy strict_auth
+- strict checks for mails from authenticated senders
+.Dl Em Default: Li no
+.It
 .Sy spf_domains
 - list of domains that would be checked with spf
 .Dl Em Default: Li empty Pq spf disabled

--- a/rmilter.conf.sample
+++ b/rmilter.conf.sample
@@ -157,7 +157,13 @@ tempdir = /tmp;
 
 # max_size - maximum size of scanned mail with clamav and dcc
 # Default: 0 (no limit)
+
 max_size = 10M;
+
+# strict_auth - strict checks for mails from authenticated senders
+# Default: no
+
+strict_auth = no;
 
 # spf_domains - path to file that contains hash of spf domains
 # Default: empty


### PR DESCRIPTION
rmilter can force spam check on mails from authenticated users, but it's not yet documented.
This patch contains some additions in the doc, the readme and the config files to talk about this.