### PR TITLE
Fixing several build issues for Ubuntu 14.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ ENDIF()
 
 IF(ENABLE_SPF MATCHES "ON")
     SET(WITH_SPF 1)
-    ProcessPackage(LIBSPF2 LIBRARY spf2 INCLUDE spf.h
+    ProcessPackage(LIBSPF2 LIBRARY spf2 INCLUDE spf2/spf.h
     	INCLUDE_SUFFIXES include/spf include/spf2
     	LIB_SUFFIXES lib/libspf2 lib64/libspf2 lib/libspf lib64/libspf
 		ROOT ${LIBSPF2_ROOT_DIR} MODULES libspf2)

--- a/debian/control
+++ b/debian/control
@@ -31,3 +31,15 @@ Architecture: any
 Section: debug
 Depends: ${shlibs:Depends}, ${misc:Depends}, rmilter (= ${binary:Version})
 Description: Debuginfo for another sendmail milter for different mail checks
+ rmilter is a standalone application that provides the following features:
+  SPF checks;
+  greylisting using memcached storage;
+  ratelimits using memcached storage;
+  checking mail via rspamd/spamassassin;
+  checking mail via clamav antivirus;
+  regexp filters;
+  DKIM signing;
+  beanstalk operations for specific messages.
+ .
+ Rmilter uses sendmail milter interface and is compatible with Sendmail
+ and Postfix MTA  as well as with other MTA that supports milter interface.

--- a/debian/control
+++ b/debian/control
@@ -25,3 +25,9 @@ Description: Another sendmail milter for different mail checks
  .
  Rmilter uses sendmail milter interface and is compatible with Sendmail
  and Postfix MTA  as well as with other MTA that supports milter interface.
+
+Package: rmilter-dbg
+Architecture: any
+Section: debug
+Depends: ${shlibs:Depends}, ${misc:Depends}, rmilter (= ${binary:Version})
+Description: Debuginfo for another sendmail milter for different mail checks

--- a/debian/rmilter.install
+++ b/debian/rmilter.install
@@ -1,0 +1,1 @@
+usr/sbin

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,8 @@ export DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed
 override_dh_auto_configure:
 	dh_auto_configure -- -DENABLE_SPF=ON \
 		-DENABLE_DKIM=ON \
-		-DMANDIR=/usr/share/man
+		-DMANDIR=/usr/share/man \
+		-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo
 
 override_dh_systemd_enable:
 	dh_systemd_enable rmilter.socket

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,6 @@ override_dh_systemd_start:
 
 override_dh_installinit:
 	dh_installinit -n
+
+override_dh_strip:
+	dh_strip --dbg-package=rmilter-dbg

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DENABLE_SPF=ON \
 		-DENABLE_DKIM=ON \
 		-DMANDIR=/usr/share/man \
+		-DCMAKE_INSTALL_PREFIX:PATH=/usr \
 		-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo
 
 override_dh_systemd_enable:


### PR DESCRIPTION
Hello! Please consider merging these fixes targeting the build issues we faced in Ubuntu 14.10. We use this platform both in dev and prod and we would like to have fresh ```rmilter``` package for reliable deployment. 

These are the errors we noticed when we tried to ```debuild``` it in Ubuntu:
1. CMake wasn't able to find ```spf.h``` despite the package ```libspf2-dev``` was installed;
2. Resulting binary package was empty;

Also we added debug package for the sake of ```gdb```.