### PR TITLE
Open the listening socket after calling daemon(3).

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -284,13 +284,13 @@ main(int argc, char *argv[])
 		msg_warn ("main: cannot start reload thread, ignoring error");
 	}
 
-	if (smfi_opensocket(true) == MI_FAILURE) {
-		msg_err("Unable to open listening socket");
+	if (daemonize && daemon (0, 0) == -1) {
+		msg_err("Unable to daemonize");
 		exit(EX_UNAVAILABLE);
 	}
 
-	if (daemonize && daemon (0, 0) == -1) {
-		msg_err("Unable to daemonize");
+	if (smfi_opensocket(true) == MI_FAILURE) {
+		msg_err("Unable to open listening socket");
 		exit(EX_UNAVAILABLE);
 	}
 


### PR DESCRIPTION
This patch is an attempt to fix #48. From the FreeBSD daemon(3) man
page:

CAVEATS
     Unless the noclose argument is non-zero, daemon() will close the first
     three file descriptors and redirect them to /dev/null.  Normally, these
     correspond to standard input, standard output, and standard error.  How‐
     ever, if any of those file descriptors refer to something else, they will
     still be closed, resulting in incorrect behavior of the calling program.
     This can happen if any of standard input, standard output, or standard
     error have been closed before the program was run.  Programs using
     daemon() should therefore either call daemon() before opening any files
     or sockets, or verify that any file descriptors obtained have values
     greater than 2.