### PR TITLE
Fix hanging on freebsd

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -285,13 +285,13 @@ main(int argc, char *argv[])
 		msg_warn ("main: cannot start reload thread, ignoring error");
 	}
 
-	if (daemonize && daemon (0, 0) == -1) {
-		msg_err("Unable to daemonize");
+	if (smfi_opensocket(true) == MI_FAILURE) {
+		msg_err("Unable to open listening socket");
 		exit(EX_UNAVAILABLE);
 	}
 
-	if (smfi_opensocket(true) == MI_FAILURE) {
-		msg_err("Unable to open listening socket");
+	if (daemonize && daemon (0, 0) == -1) {
+		msg_err("Unable to daemonize");
 		exit(EX_UNAVAILABLE);
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -281,10 +281,6 @@ main(int argc, char *argv[])
 		exit(EX_UNAVAILABLE);
 	}
 
-	if (pthread_create (&reload_thr, NULL, reload_thread, NULL)) {
-		msg_warn ("main: cannot start reload thread, ignoring error");
-	}
-
 	if (smfi_opensocket(true) == MI_FAILURE) {
 		msg_err("Unable to open listening socket");
 		exit(EX_UNAVAILABLE);
@@ -293,6 +289,10 @@ main(int argc, char *argv[])
 	if (daemonize && daemon (0, 0) == -1) {
 		msg_err("Unable to daemonize");
 		exit(EX_UNAVAILABLE);
+	}
+
+	if (pthread_create (&reload_thr, NULL, reload_thread, NULL)) {
+		msg_warn ("main: cannot start reload thread, ignoring error");
 	}
 
 	if (cfg->pid_file) {


### PR DESCRIPTION
related to #48 and #56.

There is little doubt that the `daemon(3)` call is part of the issue, because everyone seems to be able to workaround the issue using `-n` (do not daemonize on startup).

This patch has been tested using both UNIX socket and TCP socket on both FreeBSD 10.2-RELEASE i386 (@moisseev) and 10.2-RELEASE-p7 amd64 (me).