### PR TITLE
[Fix] Use the correct config value for "our_networks"

### DIFF
--- a/src/rmilter.c
+++ b/src/rmilter.c
@@ -659,7 +659,7 @@ mlfi_envfrom(SMFICTX *ctx, char **envfrom)
 		msg_info ("<%s>; mlfi_envfrom: client is authenticated as: %s",
 					priv->mlfi_id, priv->priv_user);
 	}
-	else if (radix_find_rmilter_addr (cfg->dkim_ip_tree, &priv->priv_addr) !=
+	else if (radix_find_rmilter_addr (cfg->our_networks, &priv->priv_addr) !=
 			RADIX_NO_VALUE) {
 		priv->authenticated = 1;
 		rmilter_strlcpy (priv->priv_user, priv->priv_from, sizeof (priv->priv_user));


### PR DESCRIPTION
Use the correct variable to check whether an IP is in "our_networks". This seems to be a simple oversight/typo introduced in 6bdfea03af95b22ffb1062d702e478014cd763af and should fix #177.