### PR TITLE
[Fix] Correct rmilter.conf path in Debian service

### DIFF
--- a/debian/rmilter.service
+++ b/debian/rmilter.service
@@ -4,7 +4,7 @@ Documentation=https://rspamd.com/rmilter/
 
 [Service]
 User=_rmilter
-ExecStart=/usr/sbin/rmilter -n -c /etc/rmilter/rmilter.conf
+ExecStart=/usr/sbin/rmilter -n -c /etc/rmilter.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always
 RuntimeDirectory=rmilter


### PR DESCRIPTION
We have introduce an unintentional bug with @sbadia in #182, sorry about that. The configuration file path was [correct before](https://github.com/vstakhov/rmilter/pull/182/files#diff-84ef8020a9aa12a60ba68c033150ab62) our pull-request.